### PR TITLE
chore: move ARM builds to GitHub runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         arch: ${{ github.event.inputs.arm == 'true' && fromJSON('["aarch64"]') || fromJSON('["aarch64", "x86_64"]') }}
         fedora_version: [41]
-    runs-on: ${{ matrix.arch == 'aarch64' && 'ARM64' || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
 
     steps:
       - name: Maximize build space


### PR DESCRIPTION
GitHub now gives us access to these runners for free, so this frees up Antheas' hardware.