### PR TITLE
chore: add renovate pinning configuration (except containers)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,31 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:best-practices"
+    ],
+    "rebaseWhen": "never",
+    "packageRules": [
+        {
+            "automerge": true,
+            "matchUpdateTypes": [
+                "pin",
+                "pinDigest"
+            ]
+        },
+        {
+            "enabled": false,
+            "matchUpdateTypes": [
+                "digest",
+                "pinDigest",
+                "pin"
+            ],
+            "matchDepTypes": [
+                "container"
+            ],
+            "matchFileNames": [
+                ".github/workflows/**.yaml",
+                ".github/workflows/**.yml"
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
This is the pinning config we use on bazzite-dx., should pin everything except containers on gh actions